### PR TITLE
fix(DataMapper): make addSchemaFilesForTypeOverride mutate DocumentD i…

### DIFF
--- a/packages/ui/src/components/Document/actions/FieldTypeOverride.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride.test.tsx
@@ -32,7 +32,7 @@ jest.mock('../../../services/field-type-override.service', () => ({
   FieldTypeOverrideService: {
     applyFieldTypeOverride: jest.fn(),
     revertFieldTypeOverride: jest.fn(),
-    addSchemaFilesForTypeOverride: jest.fn().mockReturnValue({}),
+    addSchemaFilesForTypeOverride: jest.fn(),
   },
 }));
 

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride.tsx
@@ -34,9 +34,8 @@ export const FieldTypeOverride: FunctionComponent<FieldTypeOverrideProps> = ({
       const document = field.ownerDocument;
       const namespaceMap = mappingTree.namespaceMap;
       const previousRefId = document.getReferenceId(namespaceMap);
-      const definition = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, schemas);
-      document.definition = definition;
-      updateDocument(document, definition, previousRefId);
+      FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, schemas);
+      updateDocument(document, document.definition, previousRefId);
     },
     [field, mappingTree.namespaceMap, updateDocument],
   );

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -138,7 +138,7 @@ describe('FieldTypeOverrideService', () => {
 
   describe('addSchemaFilesForTypeOverride', () => {
     describe('XML Schema documents', () => {
-      it('should add schema files and return updated definition with namespace map', () => {
+      it('should add schema files and mutate document.definition with namespace map', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
@@ -153,19 +153,19 @@ describe('FieldTypeOverrideService', () => {
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
         const document = result.document as XmlSchemaDocument;
 
-        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+        FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
           'ImportedTypes.xsd': getImportedTypesXsd(),
         });
 
-        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('ShipOrder.xsd');
-        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('ImportedTypes.xsd');
+        expect(Object.keys(document.definition.definitionFiles || {})).toContain('ShipOrder.xsd');
+        expect(Object.keys(document.definition.definitionFiles || {})).toContain('ImportedTypes.xsd');
 
-        const namespaceMap = updatedDef.namespaceMap || {};
+        const namespaceMap = document.definition.namespaceMap || {};
         expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
         expect(namespaceMap['ns1']).toBe('http://example.com/types');
       });
 
-      it('should preserve existing namespaces when adding new ones', () => {
+      it('should preserve existing namespaces when adding new ones and mutate document.definition', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
@@ -180,11 +180,11 @@ describe('FieldTypeOverrideService', () => {
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
         const document = result.document as XmlSchemaDocument;
 
-        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+        FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
           'ImportedTypes.xsd': getImportedTypesXsd(),
         });
 
-        const namespaceMap = updatedDef.namespaceMap || {};
+        const namespaceMap = document.definition.namespaceMap || {};
         expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
         expect(namespaceMap['custom']).toBe('http://example.com/custom');
         expect(namespaceMap['ns1']).toBe('http://example.com/types');
@@ -192,7 +192,7 @@ describe('FieldTypeOverrideService', () => {
     });
 
     describe('JSON Schema documents', () => {
-      it('should add schema files and return updated definition', () => {
+      it('should add schema files and mutate document.definition', () => {
         const mainSchema = { type: 'object', properties: { name: { type: 'string' } } };
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
@@ -210,13 +210,13 @@ describe('FieldTypeOverrideService', () => {
           },
         };
 
-        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
+        FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {
           'types.json': JSON.stringify(additionalSchema),
         });
 
-        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('main.json');
-        expect(Object.keys(updatedDef.definitionFiles || {})).toContain('types.json');
-        expect(updatedDef.namespaceMap).toEqual({});
+        expect(Object.keys(document.definition.definitionFiles || {})).toContain('main.json');
+        expect(Object.keys(document.definition.definitionFiles || {})).toContain('types.json');
+        expect(document.definition.namespaceMap).toEqual({});
       });
     });
 
@@ -234,7 +234,7 @@ describe('FieldTypeOverrideService', () => {
         }).toThrow('Cannot add schema files to primitive document');
       });
 
-      it('should handle empty additionalFiles', () => {
+      it('should handle empty additionalFiles and mutate document.definition', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
@@ -249,10 +249,10 @@ describe('FieldTypeOverrideService', () => {
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
         const document = result.document as XmlSchemaDocument;
 
-        const updatedDef = FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {});
+        FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {});
 
-        expect(updatedDef.definitionFiles).toEqual(definition.definitionFiles);
-        expect(updatedDef.namespaceMap).toEqual(definition.namespaceMap);
+        expect(document.definition.definitionFiles).toEqual(definition.definitionFiles);
+        expect(document.definition.namespaceMap).toEqual(definition.namespaceMap);
       });
     });
   });

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -321,14 +321,12 @@ export class FieldTypeOverrideService {
    * 1. Adding files to the document's schema collection (via format-specific service)
    * 2. Updating DocumentDefinition.definitionFiles with new files
    * 3. Synchronizing namespace maps (for XML Schema documents)
-   * 4. Returning updated definition for re-visualization via provider
    *
-   * The returned DocumentDefinition should be passed to `dataMapperProvider.updateDocument()`
-   * to trigger full synchronization across all three namespace map levels and persist changes.
+   * The document is modified in place. After calling this method, use
+   * {@link DataMapperProvider.updateDocument()} to persist changes and trigger re-visualization.
    *
    * @param document - The document to enhance with additional schemas
    * @param additionalFiles - Map of file paths to file contents
-   * @returns Updated DocumentDefinition with merged files and synchronized namespace map
    * @throws Error if document is PrimitiveDocument or unsupported type
    * @throws Error if schema parsing fails (propagated from format-specific service)
    *
@@ -339,31 +337,20 @@ export class FieldTypeOverrideService {
    *   'CustomTypes.xsd': schemaContent,
    * };
    *
-   * // Create updated definition
-   * const updatedDefinition = FieldTypeOverrideService.addSchemaFilesForTypeOverride(
-   *   targetDocument,
-   *   additionalFiles
-   * );
+   * FieldTypeOverrideService.addSchemaFilesForTypeOverride(targetDocument, additionalFiles);
    *
    * // Apply via provider - triggers full namespace synchronization
    * dataMapperProvider.updateDocument(
    *   targetDocument,
-   *   updatedDefinition,
+   *   targetDocument.definition,
    *   previousReferenceId
    * );
-   *
-   * // Now custom types are available for field type overrides
-   * const candidates = FieldTypeOverrideService.getAllOverrideCandidates(
-   *   targetDocument,
-   *   updatedDefinition.namespaceMap || {}
-   * );
-   * // candidates now includes types from CustomTypes.xsd
    * ```
    */
   static addSchemaFilesForTypeOverride(
     document: IDocument,
     additionalFiles: Record<string, string>,
-  ): DocumentDefinition {
+  ): void {
     if (document instanceof PrimitiveDocument) {
       throw new TypeError('Cannot add schema files to primitive document');
     }
@@ -383,7 +370,7 @@ export class FieldTypeOverrideService {
       ...additionalFiles,
     };
 
-    return new DocumentDefinition(
+    document.definition = new DocumentDefinition(
       document.definition.documentType,
       document.definition.definitionType,
       document.definition.name,


### PR DESCRIPTION
…finition

Previously, addSchemaFilesForTypeOverride returned a new DocumentDefinition, forcing callers to manually assign it back to document.definition before calling updateDocument(). This was inconsistent with other mutating service methods (applyFieldTypeOverride, revertFieldTypeOverride) that operate in place and return void.

Making the method mutate in place eliminates the awkward two-step pattern at the call site and aligns the API surface across all FieldTypeOverrideService mutation methods.