### PR TITLE
fix(DataMapper): eliminate cross-document namespace prefix collisions…

### DIFF
--- a/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
+++ b/packages/ui/src/components/Document/actions/AttachSchema/AttachSchemaModal.tsx
@@ -52,7 +52,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
   documentTypeLabel,
 }) => {
   const api = useContext(MetadataContext)!;
-  const { setIsLoading, updateDocument } = useDataMapper();
+  const { mappingTree, setIsLoading, updateDocument } = useDataMapper();
   const { clearNodeReferencesForDocument, reloadNodeReferences } = useCanvas();
   const [selectedSchemaType, setSelectedSchemaType] = useState<DocumentDefinitionType>(
     DocumentDefinitionType.XML_SCHEMA,
@@ -86,11 +86,18 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
         ? DocumentDefinitionType.JSON_SCHEMA
         : DocumentDefinitionType.XML_SCHEMA;
 
-      const result = await DocumentService.createDocument(api, documentType, schemaType, documentId, allPaths);
+      const result = await DocumentService.createDocument(
+        api,
+        documentType,
+        schemaType,
+        documentId,
+        allPaths,
+        mappingTree.namespaceMap,
+      );
       setCreateDocumentResult(result);
       setSelectedSchemaType(schemaType);
     },
-    [api, documentType, documentId],
+    [api, documentType, documentId, mappingTree.namespaceMap],
   );
 
   const onFileUpload = useCallback(async () => {
@@ -126,7 +133,11 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
       }
 
       if (createDocumentResult?.documentDefinition) {
-        const result = DocumentService.removeSchemaFile(createDocumentResult.documentDefinition, filePathToRemove);
+        const result = DocumentService.removeSchemaFile(
+          createDocumentResult.documentDefinition,
+          filePathToRemove,
+          mappingTree.namespaceMap,
+        );
         if (result.document) {
           setCreateDocumentResult(result);
           return;
@@ -134,7 +145,7 @@ export const AttachSchemaModal: FunctionComponent<AttachSchemaModalProps> = ({
       }
       await validateAndCreateDocument(remaining);
     },
-    [filePaths, validateAndCreateDocument, createDocumentResult],
+    [filePaths, validateAndCreateDocument, createDocumentResult, mappingTree.namespaceMap],
   );
 
   const onRemoveAllFiles = useCallback(() => {

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/FieldTypeOverride.tsx
@@ -36,9 +36,6 @@ export const FieldTypeOverride: FunctionComponent<FieldTypeOverrideProps> = ({
       const namespaceMap = mappingTree.namespaceMap;
       const previousRefId = document.getReferenceId(namespaceMap);
       FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, schemas);
-      // Sync new namespaces from the attached schema into the mapping tree
-      // so that type candidates get proper namespace prefixes
-      Object.assign(mappingTree.namespaceMap, document.definition.namespaceMap);
       updateDocument(document, document.definition, previousRefId);
     },
     [field, mappingTree.namespaceMap, updateDocument],

--- a/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldTypeOverride/TypeOverrideModal.test.tsx
@@ -423,7 +423,6 @@ describe('TypeOverrideModal', () => {
   it('should pre-select current type when field has existing override', () => {
     const NS_XML_SCHEMA = 'http://www.w3.org/2001/XMLSchema';
     testMappingTree.namespaceMap = { xs: NS_XML_SCHEMA };
-    testField.ownerDocument.definition.namespaceMap = { xs: NS_XML_SCHEMA };
 
     const mockCandidates: Record<string, IFieldTypeInfo> = {
       'xs:string': {

--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -333,7 +333,6 @@ export class DocumentDefinition {
     public rootElementChoice?: RootElementOption,
     public fieldTypeOverrides?: IFieldTypeOverride[],
     public choiceSelections?: IChoiceSelection[],
-    public namespaceMap?: Record<string, string>,
   ) {
     if (!definitionFiles) this.definitionFiles = {};
   }

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -129,7 +129,16 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   const [alerts, setAlerts] = useState<SendAlertProps[]>([]);
 
   useEffect(() => {
-    const documents = DocumentService.createInitialDocuments(documentInitializationModel);
+    const metadataNamespaceMap = documentInitializationModel?.namespaceMap;
+    const effectiveNamespaceMap = metadataNamespaceMap
+      ? { ...initialNamespaceMap, ...metadataNamespaceMap }
+      : { ...initialNamespaceMap };
+
+    if (metadataNamespaceMap) {
+      mappingTree.namespaceMap = effectiveNamespaceMap;
+    }
+
+    const documents = DocumentService.createInitialDocuments(documentInitializationModel, effectiveNamespaceMap);
     let latestSourceParameterMap = sourceParameterMap;
     let latestTargetBodyDocument = targetBodyDocument;
     if (documents) {
@@ -142,15 +151,6 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       }
     }
     mappingTree.documentDefinitionType = latestTargetBodyDocument.definitionType;
-
-    const metadataNamespaceMap = documentInitializationModel?.namespaceMap;
-
-    if (metadataNamespaceMap) {
-      mappingTree.namespaceMap = {
-        ...initialNamespaceMap,
-        ...metadataNamespaceMap,
-      };
-    }
 
     if (initialXsltFile) {
       const loaded = MappingSerializerService.deserialize(
@@ -285,17 +285,11 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       removeStaleMappings(document.documentType, document.documentId, document, previousDocumentReferenceId);
       setNewDocument(document.documentType, document.documentId, document);
 
-      // Sync document-level namespaces into mappingTree so that type override
-      // typeStrings always carry a prefix and can be resolved back to the correct namespace URI.
-      if (definition.namespaceMap) {
-        Object.assign(mappingTree.namespaceMap, definition.namespaceMap);
-      }
-
       setDocumentRevision((r) => r + 1);
       refreshMappingTree();
       onUpdateDocument?.(definition);
     },
-    [mappingTree.namespaceMap, onUpdateDocument, refreshMappingTree, removeStaleMappings, setNewDocument],
+    [onUpdateDocument, refreshMappingTree, removeStaleMappings, setNewDocument],
   );
 
   const sendAlert = useCallback(

--- a/packages/ui/src/services/datamapper-metadata.service.ts
+++ b/packages/ui/src/services/datamapper-metadata.service.ts
@@ -106,18 +106,16 @@ export class DataMapperMetadataService {
         DocumentType.SOURCE_BODY,
         BODY_DOCUMENT_ID,
         metadata.sourceBody,
-        namespaceMap,
       ).then((definition) => (answer.sourceBody = definition));
       const targetBodyPromise = DataMapperMetadataService.doLoadDocument(
         api,
         DocumentType.TARGET_BODY,
         BODY_DOCUMENT_ID,
         metadata.targetBody,
-        namespaceMap,
       ).then((definition) => (answer.targetBody = definition));
       const paramPromises = Object.entries(metadata.sourceParameters).reduce(
         (acc, [key, meta]) => {
-          acc[key] = DataMapperMetadataService.doLoadDocument(api, DocumentType.PARAM, key, meta, namespaceMap).then(
+          acc[key] = DataMapperMetadataService.doLoadDocument(api, DocumentType.PARAM, key, meta).then(
             (definition) => (answer.sourceParameters[key] = definition),
           );
           return acc;
@@ -135,7 +133,6 @@ export class DataMapperMetadataService {
     documentType: DocumentType,
     name: string,
     documentMetadata: IDocumentMetadata,
-    namespaceMap: Record<string, string>,
   ): Promise<DocumentDefinition> {
     return new Promise((resolve) => {
       const definitionType = documentMetadata.type ? documentMetadata.type : DocumentDefinitionType.Primitive;
@@ -159,7 +156,6 @@ export class DataMapperMetadataService {
           documentMetadata.rootElementChoice,
           documentMetadata.fieldTypeOverrides,
           documentMetadata.choiceSelections,
-          namespaceMap,
         );
         resolve(answer);
       });

--- a/packages/ui/src/services/document.service.ts
+++ b/packages/ui/src/services/document.service.ts
@@ -53,6 +53,7 @@ export class DocumentService {
     schemaType: DocumentDefinitionType,
     documentId: string,
     schemaFilePaths: string[],
+    namespaceMap: Record<string, string> = {},
   ): Promise<CreateDocumentResult> {
     try {
       const docId = documentType === DocumentType.PARAM ? documentId : BODY_DOCUMENT_ID;
@@ -67,7 +68,7 @@ export class DocumentService {
         return { validationStatus: 'error', errors: [{ message: 'Could not read schema file(s)' }] };
       }
 
-      return DocumentService.doCreateDocumentFromDefinition(documentDefinition);
+      return DocumentService.doCreateDocumentFromDefinition(documentDefinition, namespaceMap);
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (error: any) {
       const errorMessage = error?.message || 'Unknown validation error';
@@ -113,7 +114,10 @@ export class DocumentService {
     return new DocumentDefinition(documentType, definitionType, documentId, fileContents);
   }
 
-  private static doCreateDocumentFromDefinition(definition: DocumentDefinition): CreateDocumentResult {
+  private static doCreateDocumentFromDefinition(
+    definition: DocumentDefinition,
+    namespaceMap: Record<string, string> = {},
+  ): CreateDocumentResult {
     switch (definition.definitionType) {
       case DocumentDefinitionType.Primitive: {
         const document = new PrimitiveDocument(definition);
@@ -125,9 +129,9 @@ export class DocumentService {
         };
       }
       case DocumentDefinitionType.XML_SCHEMA:
-        return XmlSchemaDocumentService.createXmlSchemaDocument(definition);
+        return XmlSchemaDocumentService.createXmlSchemaDocument(definition, namespaceMap);
       case DocumentDefinitionType.JSON_SCHEMA:
-        return JsonSchemaDocumentService.createJsonSchemaDocument(definition);
+        return JsonSchemaDocumentService.createJsonSchemaDocument(definition, namespaceMap);
       default:
         return {
           validationStatus: 'error',
@@ -145,12 +149,16 @@ export class DocumentService {
    * @param filePath - The key of the schema file to remove from {@link DocumentDefinition.definitionFiles}
    * @returns A {@link CreateDocumentResult} with updated validation status, errors/warnings, and definition
    */
-  static removeSchemaFile(definition: DocumentDefinition, filePath: string): CreateDocumentResult {
+  static removeSchemaFile(
+    definition: DocumentDefinition,
+    filePath: string,
+    namespaceMap: Record<string, string> = {},
+  ): CreateDocumentResult {
     switch (definition.definitionType) {
       case DocumentDefinitionType.XML_SCHEMA:
-        return XmlSchemaDocumentService.removeSchemaFile(definition, filePath);
+        return XmlSchemaDocumentService.removeSchemaFile(definition, filePath, namespaceMap);
       case DocumentDefinitionType.JSON_SCHEMA:
-        return JsonSchemaDocumentService.removeSchemaFile(definition, filePath);
+        return JsonSchemaDocumentService.removeSchemaFile(definition, filePath, namespaceMap);
       default:
         return {
           validationStatus: 'error',
@@ -188,23 +196,26 @@ export class DocumentService {
    * @param initModel - The initialization model containing document definitions
    * @returns An object containing the source body document, source parameter map, and target body document; or null if no model is provided
    */
-  static createInitialDocuments(initModel?: DocumentInitializationModel): InitialDocumentsSet | null {
+  static createInitialDocuments(
+    initModel?: DocumentInitializationModel,
+    namespaceMap: Record<string, string> = {},
+  ): InitialDocumentsSet | null {
     if (!initModel) return null;
     const answer: InitialDocumentsSet = {
       sourceParameterMap: new Map<string, IDocument>(),
     };
     if (initModel.sourceBody) {
-      const result = DocumentService.doCreateDocumentFromDefinition(initModel.sourceBody);
+      const result = DocumentService.doCreateDocumentFromDefinition(initModel.sourceBody, namespaceMap);
       if (result.document) answer.sourceBodyDocument = result.document;
     }
     if (initModel.sourceParameters) {
-      Object.entries(initModel.sourceParameters).forEach(([key, value]) => {
-        const result = DocumentService.doCreateDocumentFromDefinition(value);
+      for (const [key, value] of Object.entries(initModel.sourceParameters)) {
+        const result = DocumentService.doCreateDocumentFromDefinition(value, namespaceMap);
         answer.sourceParameterMap.set(key, result.document ?? new PrimitiveDocument(value));
-      });
+      }
     }
     if (initModel.targetBody) {
-      const result = DocumentService.doCreateDocumentFromDefinition(initModel.targetBody);
+      const result = DocumentService.doCreateDocumentFromDefinition(initModel.targetBody, namespaceMap);
       if (result.document) answer.targetBodyDocument = result.document;
     }
     return answer;

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -138,16 +138,12 @@ describe('FieldTypeOverrideService', () => {
 
   describe('addSchemaFilesForTypeOverride', () => {
     describe('XML Schema documents', () => {
-      it('should add schema files and mutate document.definition with namespace map', () => {
+      it('should add schema files and mutate document.definition.definitionFiles', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
-          undefined,
-          undefined,
-          undefined,
-          { ns0: 'io.kaoto.datamapper.poc.test' },
         );
 
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -159,22 +155,14 @@ describe('FieldTypeOverrideService', () => {
 
         expect(Object.keys(document.definition.definitionFiles || {})).toContain('ShipOrder.xsd');
         expect(Object.keys(document.definition.definitionFiles || {})).toContain('ImportedTypes.xsd');
-
-        const namespaceMap = document.definition.namespaceMap || {};
-        expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
-        expect(namespaceMap['ns1']).toBe('http://example.com/types');
       });
 
-      it('should preserve existing namespaces when adding new ones and mutate document.definition', () => {
+      it('should make added schema types available in the collection', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
-          undefined,
-          undefined,
-          undefined,
-          { ns0: 'io.kaoto.datamapper.poc.test', custom: 'http://example.com/custom' },
         );
 
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -184,10 +172,7 @@ describe('FieldTypeOverrideService', () => {
           'ImportedTypes.xsd': getImportedTypesXsd(),
         });
 
-        const namespaceMap = document.definition.namespaceMap || {};
-        expect(namespaceMap['ns0']).toBe('io.kaoto.datamapper.poc.test');
-        expect(namespaceMap['custom']).toBe('http://example.com/custom');
-        expect(namespaceMap['ns1']).toBe('http://example.com/types');
+        expect(Object.keys(document.namedTypeFragments).some((k) => k.includes('ImportedType'))).toBe(true);
       });
     });
 
@@ -216,7 +201,6 @@ describe('FieldTypeOverrideService', () => {
 
         expect(Object.keys(document.definition.definitionFiles || {})).toContain('main.json');
         expect(Object.keys(document.definition.definitionFiles || {})).toContain('types.json');
-        expect(document.definition.namespaceMap).toEqual({});
       });
     });
 
@@ -234,16 +218,12 @@ describe('FieldTypeOverrideService', () => {
         }).toThrow('Cannot add schema files to primitive document');
       });
 
-      it('should handle empty additionalFiles and mutate document.definition', () => {
+      it('should handle empty additionalFiles and keep existing definition files', () => {
         const definition = new DocumentDefinition(
           DocumentType.SOURCE_BODY,
           DocumentDefinitionType.XML_SCHEMA,
           'test-doc',
           { 'ShipOrder.xsd': getShipOrderXsd() },
-          undefined,
-          undefined,
-          undefined,
-          { ns0: 'io.kaoto.datamapper.poc.test' },
         );
 
         const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -252,7 +232,6 @@ describe('FieldTypeOverrideService', () => {
         FieldTypeOverrideService.addSchemaFilesForTypeOverride(document, {});
 
         expect(document.definition.definitionFiles).toEqual(definition.definitionFiles);
-        expect(document.definition.namespaceMap).toEqual(definition.namespaceMap);
       });
     });
   });
@@ -418,6 +397,35 @@ describe('FieldTypeOverrideService', () => {
 
       expect(nameField.type).toBe(Types.Numeric);
       expect(nameField.typeOverride).toBe(TypeOverrideVariant.FORCE);
+    });
+
+    it('should register unknown namespaceURI in namespaceMap and store prefixed typeString', () => {
+      const doc = TestUtil.createSourceOrderDoc();
+      const stringField = doc.fields[0].fields.find((f) => f.name === 'OrderPerson');
+      if (!stringField) throw new Error('Field not found');
+
+      const newNamespace = 'http://example.com/types';
+      const candidate = {
+        displayName: 'EmployeeType',
+        typeString: 'EmployeeType',
+        type: Types.Container,
+        namespaceURI: newNamespace,
+        isBuiltIn: false,
+      };
+
+      const namespaceMap: Record<string, string> = { xs: NS_XML_SCHEMA, ns0: 'io.kaoto.datamapper.poc.test' };
+      FieldTypeOverrideService.applyFieldTypeOverride(
+        doc,
+        stringField,
+        candidate,
+        namespaceMap,
+        TypeOverrideVariant.FORCE,
+      );
+
+      expect(Object.values(namespaceMap)).toContain(newNamespace);
+      const registeredPrefix = Object.keys(namespaceMap).find((k) => namespaceMap[k] === newNamespace);
+      expect(registeredPrefix).toBeDefined();
+      expect(doc.definition.fieldTypeOverrides![0].type).toBe(`${registeredPrefix}:EmployeeType`);
     });
 
     it('should throw TypeError for PrimitiveDocument', () => {

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -183,9 +183,14 @@ export class FieldTypeOverrideService {
   ): IFieldTypeOverride {
     const schemaPath = SchemaPathService.build(field, namespaceMap);
     const originalTypeString = formatQNameWithPrefix(field.originalTypeQName, namespaceMap, field.originalType);
+    const localPart = candidate.typeString.includes(':') ? candidate.typeString.split(':')[1] : candidate.typeString;
+    const typePrefix = candidate.namespaceURI
+      ? (Object.entries(namespaceMap).find(([, uri]) => uri === candidate.namespaceURI)?.[0] ?? '')
+      : '';
+    const typeString = typePrefix ? `${typePrefix}:${localPart}` : localPart;
     return {
       schemaPath,
-      type: candidate.typeString,
+      type: typeString,
       originalType: originalTypeString,
       variant,
     };
@@ -197,6 +202,13 @@ export class FieldTypeOverrideService {
    * @deprecated Use formatQNameWithPrefix from qname-util.ts instead
    */
   static readonly formatQNameWithPrefix = formatQNameWithPrefix;
+
+  private static ensureNamespaceRegistered(namespaceURI: string | null, namespaceMap: Record<string, string>): void {
+    if (!namespaceURI) return;
+    if (Object.values(namespaceMap).includes(namespaceURI)) return;
+    const prefix = DocumentUtilService.generateNamespacePrefix(namespaceMap);
+    namespaceMap[prefix] = namespaceURI;
+  }
 
   /**
    * Apply a field type override to a field in a document.
@@ -262,6 +274,7 @@ export class FieldTypeOverrideService {
       throw new TypeError(`Unsupported document type: ${document.constructor.name}`);
     }
 
+    FieldTypeOverrideService.ensureNamespaceRegistered(candidate.namespaceURI, namespaceMap);
     const override = FieldTypeOverrideService.createFieldTypeOverride(field, candidate, namespaceMap, variant);
     const changed = DocumentUtilService.processTypeOverride(document, override, namespaceMap, parseTypeOverrideFn);
     if (changed) {
@@ -339,30 +352,22 @@ export class FieldTypeOverrideService {
       throw new TypeError('Cannot add schema files to primitive document');
     }
 
-    let updatedNamespaceMap: Record<string, string>;
-
     if (document instanceof XmlSchemaDocument) {
-      updatedNamespaceMap = XmlSchemaDocumentService.addSchemaFiles(document, additionalFiles);
+      XmlSchemaDocumentService.addSchemaFiles(document, additionalFiles);
     } else if (document instanceof JsonSchemaDocument) {
-      updatedNamespaceMap = JsonSchemaDocumentService.addSchemaFiles(document, additionalFiles);
+      JsonSchemaDocumentService.addSchemaFiles(document, additionalFiles);
     } else {
       throw new TypeError(`Unsupported document type: ${document.constructor.name}`);
     }
-
-    const mergedDefinitionFiles = {
-      ...document.definition.definitionFiles,
-      ...additionalFiles,
-    };
 
     document.definition = new DocumentDefinition(
       document.definition.documentType,
       document.definition.definitionType,
       document.definition.name,
-      mergedDefinitionFiles,
+      { ...document.definition.definitionFiles, ...additionalFiles },
       document.definition.rootElementChoice,
       document.definition.fieldTypeOverrides,
       document.definition.choiceSelections,
-      updatedNamespaceMap,
     );
   }
 

--- a/packages/ui/src/services/json-schema-document.service.test.ts
+++ b/packages/ui/src/services/json-schema-document.service.test.ts
@@ -817,7 +817,7 @@ describe('JsonSchemaDocumentService', () => {
       expect(collection.getJsonSchema('http://example.com/schemas/customer.json')).toBeDefined();
     });
 
-    it('should return empty namespace map when adding JSON schemas', () => {
+    it('should add JSON schemas to the collection', () => {
       const definition = new DocumentDefinition(
         DocumentType.SOURCE_BODY,
         DocumentDefinitionType.JSON_SCHEMA,
@@ -828,11 +828,11 @@ describe('JsonSchemaDocumentService', () => {
       const result = JsonSchemaDocumentService.createJsonSchemaDocument(definition);
       const document = result.document as JsonSchemaDocument;
 
-      const updatedNamespaceMap = JsonSchemaDocumentService.addSchemaFiles(document, {
-        'additional.json': '{"type": "object", "properties": {"field": {"type": "string"}}}',
+      JsonSchemaDocumentService.addSchemaFiles(document, {
+        'additional.json': '{"$id": "http://example.com/additional", "type": "object"}',
       });
 
-      expect(updatedNamespaceMap).toEqual({});
+      expect(document.schemaCollection.getJsonSchema('http://example.com/additional')).toBeDefined();
     });
   });
 

--- a/packages/ui/src/services/json-schema-document.service.ts
+++ b/packages/ui/src/services/json-schema-document.service.ts
@@ -41,7 +41,10 @@ export class JsonSchemaDocumentService {
    * @param definition The DocumentDefinition containing schema information
    * @returns CreateJsonSchemaDocumentResult with document and validation status
    */
-  static createJsonSchemaDocument(definition: DocumentDefinition): CreateJsonSchemaDocumentResult {
+  static createJsonSchemaDocument(
+    definition: DocumentDefinition,
+    namespaceMap: Record<string, string> = {},
+  ): CreateJsonSchemaDocumentResult {
     const filePaths = Object.keys(definition.definitionFiles || {});
     if (filePaths.length === 0) {
       return {
@@ -106,7 +109,7 @@ export class JsonSchemaDocumentService {
       document,
       definition.fieldTypeOverrides ?? [],
       definition.choiceSelections ?? [],
-      definition.namespaceMap || {},
+      namespaceMap,
       JsonSchemaTypesService.parseTypeOverride,
     );
 
@@ -127,9 +130,8 @@ export class JsonSchemaDocumentService {
    * This is useful when field type overrides reference types defined in additional schema files.
    * @param document - The document whose schema collection will be updated
    * @param additionalFiles - Map of file paths to file contents to add
-   * @returns Empty namespace map (JSON Schema doesn't use namespaces, but this maintains API consistency)
    */
-  static addSchemaFiles(document: JsonSchemaDocument, additionalFiles: Record<string, string>): Record<string, string> {
+  static addSchemaFiles(document: JsonSchemaDocument, additionalFiles: Record<string, string>): void {
     const collection = document.schemaCollection;
 
     collection.addDefinitionFiles(additionalFiles);
@@ -143,8 +145,6 @@ export class JsonSchemaDocumentService {
         throw new Error(`Failed to add schema file "${filePath}": ${errorMessage}`);
       }
     }
-
-    return {};
   }
 
   /**
@@ -157,7 +157,11 @@ export class JsonSchemaDocumentService {
    * @param filePath - The key of the schema file to remove from {@link DocumentDefinition.definitionFiles}
    * @returns A {@link CreateJsonSchemaDocumentResult} with updated validation status, errors/warnings, and definition
    */
-  static removeSchemaFile(definition: DocumentDefinition, filePath: string): CreateJsonSchemaDocumentResult {
+  static removeSchemaFile(
+    definition: DocumentDefinition,
+    filePath: string,
+    namespaceMap: Record<string, string> = {},
+  ): CreateJsonSchemaDocumentResult {
     const updatedFiles = { ...definition.definitionFiles };
     delete updatedFiles[filePath];
 
@@ -169,12 +173,11 @@ export class JsonSchemaDocumentService {
       definition.rootElementChoice,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
-      definition.namespaceMap,
     );
 
     // Try to create the Document object. It could fail if the primary schema is the removed schema file.
     // In that case, we unset updatedDefinition.rootElementChoice and retry.
-    const result = JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition);
+    const result = JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition, namespaceMap);
 
     // If it succeeds or a primary schema not set, return as it is
     if (result.document || !definition.rootElementChoice) {
@@ -183,7 +186,7 @@ export class JsonSchemaDocumentService {
 
     // Unset the primary schema and retry
     updatedDefinition.rootElementChoice = undefined;
-    return JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition);
+    return JsonSchemaDocumentService.createJsonSchemaDocument(updatedDefinition, namespaceMap);
   }
 
   private static populateDependencyMetadata(

--- a/packages/ui/src/services/xml-schema-document.service.test.ts
+++ b/packages/ui/src/services/xml-schema-document.service.test.ts
@@ -1103,7 +1103,7 @@ describe('XmlSchemaDocumentService', () => {
       expect(importedType).toBeDefined();
     });
 
-    it('should return updated namespace map when adding schemas with new namespaces', () => {
+    it('should make added schemas available in the collection', () => {
       const mainSchema = `<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="http://example.com/main">
@@ -1115,10 +1115,6 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         { 'main.xsd': mainSchema },
-        undefined,
-        undefined,
-        undefined,
-        { ns0: 'http://example.com/main' },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -1134,13 +1130,10 @@ describe('XmlSchemaDocumentService', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const updatedNamespaceMap = XmlSchemaDocumentService.addSchemaFiles(document, {
-        'types.xsd': additionalSchema,
-      });
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'types.xsd': additionalSchema });
 
-      expect(updatedNamespaceMap['ns0']).toBe('http://example.com/main');
-      expect(updatedNamespaceMap['ns1']).toBe('http://example.com/types');
-      expect(Object.keys(updatedNamespaceMap).length).toBe(2);
+      const customQName = new QName('http://example.com/types', 'CustomType');
+      expect(document.xmlSchemaCollection.getTypeByQName(customQName)).toBeDefined();
     });
 
     it('should generate prefixes following sequential pattern (ns0, ns1, ns2, ...)', () => {
@@ -1160,54 +1153,7 @@ describe('XmlSchemaDocumentService', () => {
       expect(prefix3).toBe('ns3');
     });
 
-    it('should filter out standard XML/XSD namespaces', () => {
-      const xsdSchema = `<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="Test" type="xs:string"/>
-</xs:schema>`;
-
-      const customSchema = `<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://example.com/custom">
-  <xs:element name="Custom" type="xs:string"/>
-</xs:schema>`;
-
-      const namespaces = XmlSchemaDocumentService['extractNamespacesFromSchemas'](
-        {
-          'xsd.xsd': xsdSchema,
-          'custom.xsd': customSchema,
-        },
-        {},
-      );
-
-      expect(Object.values(namespaces)).not.toContain('http://www.w3.org/2001/XMLSchema');
-      expect(Object.values(namespaces)).toContain('http://example.com/custom');
-      expect(Object.keys(namespaces).length).toBe(1);
-    });
-
-    it('should not create duplicate entries for same namespace', () => {
-      const existingMap = { ns0: 'http://example.com/main' };
-
-      const mainSchema = `<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://example.com/main">
-  <xs:element name="Test" type="xs:string"/>
-</xs:schema>`;
-
-      const newNamespaces = XmlSchemaDocumentService['extractNamespacesFromSchemas'](
-        { 'duplicate.xsd': mainSchema },
-        existingMap,
-      );
-
-      expect(Object.keys(newNamespaces).length).toBe(0);
-
-      const merged = XmlSchemaDocumentService['mergeNamespaceMaps'](existingMap, newNamespaces);
-      expect(Object.keys(merged).length).toBe(1);
-      expect(merged['ns0']).toBe('http://example.com/main');
-    });
-
-    it('should maintain stable prefixes across multiple addSchemaFiles() calls', () => {
+    it('should support multiple sequential addSchemaFiles() calls', () => {
       const mainSchema = `<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="http://example.com/main">
@@ -1219,10 +1165,6 @@ describe('XmlSchemaDocumentService', () => {
         DocumentDefinitionType.XML_SCHEMA,
         'test-doc',
         { 'main.xsd': mainSchema },
-        undefined,
-        undefined,
-        undefined,
-        { ns0: 'http://example.com/main' },
       );
 
       const result = XmlSchemaDocumentService.createXmlSchemaDocument(definition);
@@ -1238,15 +1180,7 @@ describe('XmlSchemaDocumentService', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const map1 = XmlSchemaDocumentService.addSchemaFiles(document, {
-        'types.xsd': schemaA,
-      });
-
-      expect(map1['ns0']).toBe('http://example.com/main');
-      expect(map1['ns1']).toBe('http://example.com/types');
-      expect(Object.keys(map1).length).toBe(2);
-
-      document.definition.namespaceMap = map1;
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'types.xsd': schemaA });
 
       const schemaB = `<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -1258,14 +1192,12 @@ describe('XmlSchemaDocumentService', () => {
   </xs:complexType>
 </xs:schema>`;
 
-      const map2 = XmlSchemaDocumentService.addSchemaFiles(document, {
-        'other.xsd': schemaB,
-      });
+      XmlSchemaDocumentService.addSchemaFiles(document, { 'other.xsd': schemaB });
 
-      expect(map2['ns0']).toBe('http://example.com/main');
-      expect(map2['ns1']).toBe('http://example.com/types');
-      expect(map2['ns2']).toBe('http://example.com/other');
-      expect(Object.keys(map2).length).toBe(3);
+      const typeAQName = new QName('http://example.com/types', 'TypeA');
+      const typeBQName = new QName('http://example.com/other', 'TypeB');
+      expect(document.xmlSchemaCollection.getTypeByQName(typeAQName)).toBeDefined();
+      expect(document.xmlSchemaCollection.getTypeByQName(typeBQName)).toBeDefined();
     });
   });
 

--- a/packages/ui/src/services/xml-schema-document.service.ts
+++ b/packages/ui/src/services/xml-schema-document.service.ts
@@ -62,7 +62,10 @@ export class XmlSchemaDocumentService {
    * @param definition The DocumentDefinition containing schema information and configuration
    * @returns {@link CreateXmlSchemaDocumentResult} with document, root element options, and validation status
    */
-  static createXmlSchemaDocument(definition: DocumentDefinition): CreateXmlSchemaDocumentResult {
+  static createXmlSchemaDocument(
+    definition: DocumentDefinition,
+    namespaceMap: Record<string, string> = {},
+  ): CreateXmlSchemaDocumentResult {
     const collection = new XmlSchemaCollection();
     const definitionFiles = definition.definitionFiles || {};
     collection.getSchemaResolver().addFiles(definitionFiles);
@@ -91,8 +94,6 @@ export class XmlSchemaDocumentService {
       return rootElement;
     }
 
-    XmlSchemaDocumentService.ensureNamespaceMap(definition, collection);
-
     const document = new XmlSchemaDocument(definition, collection, rootElement);
 
     XmlSchemaDocumentService.populateNamedTypeFragments(document);
@@ -102,7 +103,7 @@ export class XmlSchemaDocumentService {
       document,
       definition.fieldTypeOverrides ?? [],
       definition.choiceSelections ?? [],
-      definition.namespaceMap || {},
+      namespaceMap,
       XmlSchemaTypesService.parseTypeOverride,
     );
 
@@ -205,37 +206,16 @@ export class XmlSchemaDocumentService {
   }
 
   /**
-   * Helper method to ensure namespace map is populated.
-   */
-  private static ensureNamespaceMap(definition: DocumentDefinition, collection: XmlSchemaCollection): void {
-    if (!definition.namespaceMap) {
-      const extractedNamespaces = XmlSchemaDocumentService.extractNamespacesFromCollection(collection, {});
-      if (Object.keys(extractedNamespaces).length > 0) {
-        definition.namespaceMap = extractedNamespaces;
-      }
-    }
-  }
-
-  /**
    * Adds additional schema files to an existing document's schema collection.
    * This is useful when field type overrides reference types defined in additional schema files.
    * @param document - The document whose schema collection will be updated
    * @param additionalFiles - Map of file paths to file contents to add
-   * @returns Updated namespace map with new namespaces from added schemas
    */
-  static addSchemaFiles(document: XmlSchemaDocument, additionalFiles: Record<string, string>): Record<string, string> {
+  static addSchemaFiles(document: XmlSchemaDocument, additionalFiles: Record<string, string>): void {
     const collection = document.xmlSchemaCollection;
-    const resolver = collection.getSchemaResolver();
-
-    resolver.addFiles(additionalFiles);
-
+    collection.getSchemaResolver().addFiles(additionalFiles);
     XmlSchemaDocumentUtilService.loadXmlSchemaFiles(collection, additionalFiles);
     XmlSchemaDocumentService.populateNamedTypeFragments(document);
-
-    const existingNamespaceMap = document.definition.namespaceMap || {};
-    const newNamespaces = XmlSchemaDocumentService.extractNamespacesFromSchemas(additionalFiles, existingNamespaceMap);
-
-    return XmlSchemaDocumentService.mergeNamespaceMaps(existingNamespaceMap, newNamespaces);
   }
 
   /**
@@ -248,7 +228,11 @@ export class XmlSchemaDocumentService {
    * @param filePath - The key of the schema file to remove from {@link DocumentDefinition.definitionFiles}
    * @returns A {@link CreateXmlSchemaDocumentResult} with updated validation status, errors/warnings, and definition
    */
-  static removeSchemaFile(definition: DocumentDefinition, filePath: string): CreateXmlSchemaDocumentResult {
+  static removeSchemaFile(
+    definition: DocumentDefinition,
+    filePath: string,
+    namespaceMap: Record<string, string> = {},
+  ): CreateXmlSchemaDocumentResult {
     const updatedFiles = { ...definition.definitionFiles };
     delete updatedFiles[filePath];
 
@@ -260,12 +244,11 @@ export class XmlSchemaDocumentService {
       definition.rootElementChoice,
       definition.fieldTypeOverrides,
       definition.choiceSelections,
-      definition.namespaceMap,
     );
 
     // Try to create the Document object. It could fail if the root element user chose was defined in the removed
     // schema file. In that case, we unset `updatedDefinition.rootElementChoice` and retry.
-    const result = XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition);
+    const result = XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition, namespaceMap);
 
     // If it succeeds or a root element was not set, return as it is
     if (result.document || !definition.rootElementChoice) {
@@ -274,103 +257,7 @@ export class XmlSchemaDocumentService {
 
     // Unset the root element and retry
     updatedDefinition.rootElementChoice = undefined;
-    return XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition);
-  }
-
-  /**
-   * Extracts namespace mappings from XML schema files.
-   * Parses each schema file to extract targetNamespace and generates appropriate prefixes.
-   * Filters out standard XML/XSD namespaces.
-   *
-   * @param schemaFiles - Map of file paths to schema file contents
-   * @param existingNamespaceMap - Existing namespace map to check for conflicts
-   * @returns Map of generated prefix -> namespace URI
-   */
-  /**
-   * Extracts namespace mappings from an already-parsed XmlSchemaCollection.
-   * Unlike extractNamespacesFromSchemas, this reuses an existing collection
-   * and avoids re-parsing schema files.
-   */
-  private static extractNamespacesFromCollection(
-    collection: XmlSchemaCollection,
-    existingNamespaceMap: Record<string, string>,
-  ): Record<string, string> {
-    const newNamespaces: Record<string, string> = {};
-
-    for (const schema of collection.getUserSchemas()) {
-      const targetNamespace = schema.getTargetNamespace();
-      if (!targetNamespace || XmlSchemaDocumentUtilService.isStandardXmlNamespace(targetNamespace)) continue;
-
-      const alreadyMapped =
-        Object.values(existingNamespaceMap).includes(targetNamespace) ||
-        Object.values(newNamespaces).includes(targetNamespace);
-      if (alreadyMapped) continue;
-
-      const combinedMap = { ...existingNamespaceMap, ...newNamespaces };
-      const prefix = DocumentUtilService.generateNamespacePrefix(combinedMap);
-      newNamespaces[prefix] = targetNamespace;
-    }
-
-    return newNamespaces;
-  }
-
-  private static extractNamespacesFromSchemas(
-    schemaFiles: Record<string, string>,
-    existingNamespaceMap: Record<string, string>,
-  ): Record<string, string> {
-    const newNamespaces: Record<string, string> = {};
-    const tempCollection = new XmlSchemaCollection();
-
-    for (const [filePath, content] of Object.entries(schemaFiles)) {
-      try {
-        const schema = tempCollection.read(content, () => {}, filePath);
-        const targetNamespace = schema.getTargetNamespace();
-
-        if (!targetNamespace) {
-          continue;
-        }
-
-        const standardNamespaces = new Set([
-          'http://www.w3.org/2001/XMLSchema',
-          'http://www.w3.org/XML/1998/namespace',
-        ]);
-
-        if (standardNamespaces.has(targetNamespace)) {
-          continue;
-        }
-
-        const alreadyMapped =
-          Object.values(existingNamespaceMap).includes(targetNamespace) ||
-          Object.values(newNamespaces).includes(targetNamespace);
-
-        if (alreadyMapped) {
-          continue;
-        }
-
-        const combinedMap = { ...existingNamespaceMap, ...newNamespaces };
-        const prefix = DocumentUtilService.generateNamespacePrefix(combinedMap);
-        newNamespaces[prefix] = targetNamespace;
-      } catch (error) {
-        console.warn(`Failed to extract namespace from ${filePath}:`, error);
-      }
-    }
-
-    return newNamespaces;
-  }
-
-  /**
-   * Merges existing namespace map with newly extracted namespaces.
-   * Existing mappings take precedence to avoid breaking existing references.
-   *
-   * @param existingMap - Current namespace map from DocumentDefinition
-   * @param newNamespaces - Newly extracted namespace mappings
-   * @returns Merged namespace map
-   */
-  private static mergeNamespaceMaps(
-    existingMap: Record<string, string>,
-    newNamespaces: Record<string, string>,
-  ): Record<string, string> {
-    return { ...existingMap, ...newNamespaces };
+    return XmlSchemaDocumentService.createXmlSchemaDocument(updatedDefinition, namespaceMap);
   }
 
   /**


### PR DESCRIPTION
… in type overrides

Per-document namespace extraction generated prefixes independently, so two schemas could both claim ns0 — the last Object.assign win silently corrupted the global namespace map. Replace with a single authoritative mappingTree.namespaceMap passed directly into document creation and type override application; lazily register new namespaces on demand instead of eagerly extracting them per document.